### PR TITLE
Some improvements

### DIFF
--- a/KSGuideController/KSGuideController.swift
+++ b/KSGuideController/KSGuideController.swift
@@ -147,8 +147,8 @@ public class KSGuideController: UIViewController {
     override public func viewDidLoad() {
         super.viewDidLoad()
         
-        // Do any additional setup after loading  the view.
-        configViews()
+        let index = currentIndex
+        currentIndex = index
     }
     
     public override var prefersStatusBarHidden: Bool {
@@ -193,7 +193,10 @@ public class KSGuideController: UIViewController {
         let fromPath = maskLayer.path
         
         maskLayer.fillColor = UIColor.black.cgColor
-        let highlightedPath = UIBezierPath(roundedRect: hollowFrame, cornerRadius: maskCornerRadius)
+        var radius = maskCornerRadius
+        let frame = hollowFrame
+        radius = min(radius, min(frame.width / 2.0, frame.height / 2.0))
+        let highlightedPath = UIBezierPath(roundedRect: hollowFrame, cornerRadius: radius)
         let toPath = UIBezierPath(rect: view.bounds)
         toPath.append(highlightedPath)
         maskLayer.path = toPath.cgPath

--- a/KSGuideController/KSGuideController.swift
+++ b/KSGuideController/KSGuideController.swift
@@ -229,13 +229,8 @@ public class KSGuideController: UIViewController {
                                y: hollowFrame.maxY + spacing,
                                width: imageSize.width,
                                height: imageSize.height)
-            var x: CGFloat = 0
-            if size.width < hollowFrame.size.width {
-                x = arrowRect.maxX - size.width / 2
-            } else {
-                x = padding
-            }
-            textRect = CGRect(x: min(x, maxX),
+            let x: CGFloat = min(maxX, arrowRect.maxX - size.width / 2)
+            textRect = CGRect(x: x,
                               y: arrowRect.maxY + spacing,
                               width: size.width,
                               height: size.height)
@@ -245,13 +240,8 @@ public class KSGuideController: UIViewController {
                                y: hollowFrame.maxY + spacing,
                                width: imageSize.width,
                                height: imageSize.height)
-            var x: CGFloat = 0
-            if size.width < hollowFrame.size.width {
-                x = arrowRect.minX - size.width / 2
-            } else {
-                x = padding + maxWidth - size.width
-            }
-            textRect = CGRect(x: min(x, maxX),
+            let x: CGFloat = min(maxX, arrowRect.minX - size.width / 2)
+            textRect = CGRect(x: x,
                               y: arrowRect.maxY + spacing,
                               width: size.width,
                               height: size.height)
@@ -262,13 +252,8 @@ public class KSGuideController: UIViewController {
                                y: hollowFrame.minY - spacing - imageSize.height,
                                width: imageSize.width,
                                height: imageSize.height)
-            var x: CGFloat = 0
-            if size.width < hollowFrame.size.width {
-                x = arrowRect.maxX - size.width / 2
-            } else {
-                x = padding
-            }
-            textRect = CGRect(x: min(x, maxX),
+            let x: CGFloat = min(maxX, arrowRect.maxX - size.width / 2)
+            textRect = CGRect(x: x,
                               y: arrowRect.minY - spacing - size.height,
                               width: size.width,
                               height: size.height)
@@ -279,13 +264,8 @@ public class KSGuideController: UIViewController {
                                y: hollowFrame.minY - spacing - imageSize.height,
                                width: imageSize.width,
                                height: imageSize.height)
-            var x: CGFloat = 0
-            if size.width < hollowFrame.size.width {
-                x = arrowRect.minX - size.width / 2
-            } else {
-                x = padding + maxWidth - size.width
-            }
-            textRect = CGRect(x: min(x, maxX),
+            let x: CGFloat = min(maxX, arrowRect.minX - size.width / 2)
+            textRect = CGRect(x: x,
                               y: arrowRect.minY - spacing - size.height,
                               width: size.width,
                               height: size.height)

--- a/KSGuideController/KSGuideController.swift
+++ b/KSGuideController/KSGuideController.swift
@@ -21,7 +21,7 @@ public class KSGuideController: UIViewController {
     public typealias IndexChangeBlock = ((_ index: Int, _ item: KSGuideItem) -> Void)
     
     private var items = [KSGuideItem]()
-    private var currentIndex: Int = 0 {
+    public var currentIndex: Int = -1 {
         didSet {
             self.indexWillChangeBlock?(currentIndex, self.currentItem)
             configViews()
@@ -147,8 +147,7 @@ public class KSGuideController: UIViewController {
     override public func viewDidLoad() {
         super.viewDidLoad()
         
-        let index = currentIndex
-        currentIndex = index
+        currentIndex = 0
     }
     
     public override var prefersStatusBarHidden: Bool {

--- a/KSGuideController/KSGuideController.swift
+++ b/KSGuideController/KSGuideController.swift
@@ -18,12 +18,14 @@ public class KSGuideController: UIViewController {
     }
     
     public typealias CompletionBlock = (() -> Void)
-    public typealias IndexChangedBlock = ((_ index: Int, _ item: KSGuideItem) -> Void)
+    public typealias IndexChangeBlock = ((_ index: Int, _ item: KSGuideItem) -> Void)
     
     private var items = [KSGuideItem]()
     private var currentIndex: Int = 0 {
         didSet {
+            self.indexWillChangeBlock?(currentIndex, self.currentItem)
             configViews()
+            self.indexDidChangeBlock?(currentIndex, self.currentItem)
         }
     }
     private var currentItem: KSGuideItem {
@@ -35,7 +37,8 @@ public class KSGuideController: UIViewController {
     private let textLabel = UILabel()
     private let maskLayer = CAShapeLayer()
     private var completion: CompletionBlock?
-    private var indexChangedBlock: IndexChangedBlock?
+    private var indexWillChangeBlock: IndexChangeBlock?
+    private var indexDidChangeBlock: IndexChangeBlock?
     private var guideKey: String?
     
     public var maskCornerRadius: CGFloat = 5
@@ -51,6 +54,8 @@ public class KSGuideController: UIViewController {
     public var animatedMask = true
     public var animatedText = true
     public var animatedArrow = true
+    
+    public var statusBarHidden = false
     
     private var maskCenter: CGPoint {
         get {
@@ -127,8 +132,12 @@ public class KSGuideController: UIViewController {
         }
     }
     
-    public func setIndexChangeBlock(_ block: IndexChangedBlock?) {
-        indexChangedBlock = block
+    public func setIndexWillChangeBlock(_ block: IndexChangeBlock?) {
+        indexWillChangeBlock = block
+    }
+    
+    public func setIndexDidChangeBlock(_ block: IndexChangeBlock?) {
+        indexDidChangeBlock = block;
     }
     
     required public init?(coder aDecoder: NSCoder) {
@@ -140,6 +149,10 @@ public class KSGuideController: UIViewController {
         
         // Do any additional setup after loading  the view.
         configViews()
+    }
+    
+    public override var prefersStatusBarHidden: Bool {
+        return statusBarHidden
     }
     
     public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -306,7 +319,6 @@ public class KSGuideController: UIViewController {
     public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         if currentIndex < items.count - 1 {
             currentIndex += 1
-            indexChangedBlock?(currentIndex, currentItem)
         } else {
             dismiss(animated: true, completion: completion)
         }

--- a/KSGuideController/KSGuideController.swift
+++ b/KSGuideController/KSGuideController.swift
@@ -221,6 +221,7 @@ public class KSGuideController: UIViewController {
         let imageSize = arrowImageView.image!.size
         let maxWidth = view.frame.size.width - padding * 2
         let size = currentItem.text.ks_size(of: font, maxWidth: maxWidth)
+        let maxX = padding + maxWidth - size.width
         switch region {
             
         case .upperLeft:
@@ -235,7 +236,7 @@ public class KSGuideController: UIViewController {
             } else {
                 x = padding
             }
-            textRect = CGRect(x: x,
+            textRect = CGRect(x: min(x, maxX),
                               y: arrowRect.maxY + spacing,
                               width: size.width,
                               height: size.height)
@@ -251,7 +252,7 @@ public class KSGuideController: UIViewController {
             } else {
                 x = padding + maxWidth - size.width
             }
-            textRect = CGRect(x: x,
+            textRect = CGRect(x: min(x, maxX),
                               y: arrowRect.maxY + spacing,
                               width: size.width,
                               height: size.height)
@@ -268,7 +269,7 @@ public class KSGuideController: UIViewController {
             } else {
                 x = padding
             }
-            textRect = CGRect(x: x,
+            textRect = CGRect(x: min(x, maxX),
                               y: arrowRect.minY - spacing - size.height,
                               width: size.width,
                               height: size.height)
@@ -285,7 +286,7 @@ public class KSGuideController: UIViewController {
             } else {
                 x = padding + maxWidth - size.width
             }
-            textRect = CGRect(x: x,
+            textRect = CGRect(x: min(x, maxX),
                               y: arrowRect.minY - spacing - size.height,
                               width: size.width,
                               height: size.height)

--- a/KSGuideController/KSGuideItem.swift
+++ b/KSGuideController/KSGuideItem.swift
@@ -9,9 +9,9 @@
 import UIKit
 
 public class KSGuideItem: NSObject {
-    var sourceView: UIView?
-    var rect: CGRect = .zero
-    var text: String!
+    public var sourceView: UIView?
+    public var rect: CGRect = .zero
+    public var text: String!
     
     public init(sourceView: UIView, text: String) {
         self.sourceView = sourceView


### PR DESCRIPTION
Hi,

I've made some improvements in my fork, I don't know if you could accept my pull request, as I've changed the block name after the animation, so that this version won't be backward compatible.

Here are the key improvements:
- Added `indexWillChangeBlock` before the animation, so that we can update the underlying view before setting the mask's frame.
- Added `indexDidChangeBlock` after the animation.
- Make the`currentIndex` public, so that we can jump to a specific index directly.
- Added `statusBarHidden`, so that we can hide the status bar.
- Make `KSGuideItem`'s properties public so that we can update them before the animation, for example, a table view cell that hasn't been created when we create the `KSGuideItem`.
- Fixed a bug of mask's x position. 