### PR TITLE
Make sure arrowColor is correctly applied

### DIFF
--- a/KSGuideController/Extensions.swift
+++ b/KSGuideController/Extensions.swift
@@ -16,17 +16,3 @@ extension String {
         return size;
     }
 }
-
-extension UIImage {
-    func ks_image(with tintColor: UIColor) -> UIImage? {
-        UIGraphicsBeginImageContextWithOptions(size, false, 0)
-        tintColor.setFill()
-        let bounds = CGRect(x: 0, y: 0, width: size.width, height: size.height)
-        UIRectFill(bounds)
-        draw(in: bounds, blendMode: .overlay, alpha: 1)
-        draw(in: bounds, blendMode: .destinationIn, alpha: 1)
-        let image = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        return image
-    }
-}

--- a/KSGuideController/KSGuideController.swift
+++ b/KSGuideController/KSGuideController.swift
@@ -170,10 +170,11 @@ public class KSGuideController: UIViewController {
         view.backgroundColor = UIColor(white: 0, alpha: backgroundAlpha)
         
         if let image = arrowImage {
-            arrowImageView.image = image.ks_image(with: arrowColor)
+            arrowImageView.image = image
         } else {
-            arrowImageView.image = UIImage(named: "guide_arrow", in: Bundle(for: KSGuideController.self), compatibleWith: nil)?.ks_image(with: arrowColor)
+            arrowImageView.image = UIImage(named: "guide_arrow", in: Bundle(for: KSGuideController.self), compatibleWith: nil)
         }
+        arrowImageView.image = arrowImageView.image?.withRenderingMode(UIImageRenderingMode.alwaysTemplate)
         arrowImageView.tintColor = arrowColor
         view.addSubview(arrowImageView)
         


### PR DESCRIPTION
Hi,

Sorry to trouble you again 😂

Our designer found that the arrow colour looks different than the text colour. I noticed that you created another copy of image by changing its colour.

But actually we can simply use Template Image mode to make a template image, so that UIImageView's could render the image with its `tintColor` correctly. 

Best regards,